### PR TITLE
Hotfix: update invidious url, remove www from link

### DIFF
--- a/app/utils/filter_utils.py
+++ b/app/utils/filter_utils.py
@@ -43,7 +43,7 @@ def get_site_alt(link: str):
         link = link.replace(site_key, SITE_ALTS[site_key])
         break
 
-    return link.replace('www.', '')
+    return link.replace('www.', '').replace('//m.', '//')
 
 
 def filter_link_args(query_link):

--- a/app/utils/filter_utils.py
+++ b/app/utils/filter_utils.py
@@ -18,7 +18,7 @@ BLACKLIST = [
 
 SITE_ALTS = {
     'twitter.com': 'nitter.net',
-    'youtube.com': 'invidiou.site',
+    'youtube.com': 'invidious.snopyta.org',
     'instagram.com': 'bibliogram.art/u'
 }
 
@@ -43,7 +43,7 @@ def get_site_alt(link: str):
         link = link.replace(site_key, SITE_ALTS[site_key])
         break
 
-    return link
+    return link.replace('www.', '')
 
 
 def filter_link_args(query_link):


### PR DESCRIPTION
The invidious instance has been updated to invidious.snopyta.org, since
this instance is more reliable and has more users according to
instances.invidio.us

All site alternative redirects now redirect without the 'www' subdomain,
since most of the alternative sites don't have this subdomain set up.