### PR TITLE
Fix heroku https upgrade, add funding options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# These are supported funding model platforms
+github: benbusby
+ko_fi: benbusby
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,13 @@ ENV HTTPS_ONLY=$use_https
 ARG whoogle_port=5000
 ENV EXPOSE_PORT=$whoogle_port
 
+ARG twitter_alt=''
+ENV WHOOGLE_ALT_TW=$twitter_alt
+ARG youtube_alt=''
+ENV WHOOGLE_ALT_YT=$youtube_alt
+ARG instagram_alt=''
+ENV WHOOGLE_ALT_YT=$instagram_alt
+
 COPY . .
 
 EXPOSE $EXPOSE_PORT

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Description=Whoogle
 #Environment=WHOOGLE_PROXY_PASS=<proxy password>
 #Environment=WHOOGLE_PROXY_TYPE=<proxy type (http|proxy4|proxy5)
 #Environment=WHOOGLE_PROXY_LOC=<proxy host/ip>
+# Site alternative configurations, uncomment to enable
+# Note: If not set, the feature will still be available
+# with default values. 
+#Environment=WHOOGLE_ALT_TW=nitter.net
+#Environment=WHOOGLE_ALT_YT=invidious.snopyta.org
+#Environment=WHOOGLE_ALT_IG=bibliogram.art/u
 Type=simple
 User=root
 WorkingDirectory=<whoogle_directory>
@@ -229,7 +235,10 @@ There are a few optional environment variables available for customizing a Whoog
 | WHOOGLE_PROXY_TYPE | The type of the proxy server. Can be "socks5", "socks4", or "http".           |
 | WHOOGLE_PROXY_LOC  | The location of the proxy server (host or ip).                 |
 | EXPOSE_PORT        | The port where Whoogle will be exposed.                        |
-| HTTPS_ONLY         | Enforce HTTPS. (See [here](https://github.com/benbusby/whoogle-search#https-enforcement))                            |
+| HTTPS_ONLY         | Enforce HTTPS. (See [here](https://github.com/benbusby/whoogle-search#https-enforcement)) |
+| WHOOGLE_ALT_TW     | The twitter.com alternative to use when site alternatives are enabled in the config. |
+| WHOOGLE_ALT_YT     | The youtube.com alternative to use when site alternatives are enabled in the config. |
+| WHOOGLE_ALT_IG     | The instagram.com alternative to use when site alternatives are enabled in the config. |
 
 ## Usage
 Same as most search engines, with the exception of filtering by time range.

--- a/app.json
+++ b/app.json
@@ -46,17 +46,17 @@
       "required": false
     },
     "WHOOGLE_ALT_TW": {
-      "description": "The site to use as a replacement for twitter.com when site alternatives are enabled in the config."
+      "description": "The site to use as a replacement for twitter.com when site alternatives are enabled in the config.",
       "value": "",
       "required": false
     },
     "WHOOGLE_ALT_YT": {
-      "description": "The site to use as a replacement for youtube.com when site alternatives are enabled in the config."
+      "description": "The site to use as a replacement for youtube.com when site alternatives are enabled in the config.",
       "value": "",
       "required": false
     },
     "WHOOGLE_ALT_IG": {
-      "description": "The site to use as a replacement for instagram.com when site alternatives are enabled in the config."
+      "description": "The site to use as a replacement for instagram.com when site alternatives are enabled in the config.",
       "value": "",
       "required": false
     }

--- a/app.json
+++ b/app.json
@@ -44,6 +44,21 @@
       "description": "The location of the proxy server (host or ip). Leave empty to disable.",
       "value": "",
       "required": false
+    },
+    "WHOOGLE_ALT_TW": {
+      "description": "The site to use as a replacement for twitter.com when site alternatives are enabled in the config."
+      "value": "",
+      "required": false
+    },
+    "WHOOGLE_ALT_YT": {
+      "description": "The site to use as a replacement for youtube.com when site alternatives are enabled in the config."
+      "value": "",
+      "required": false
+    },
+    "WHOOGLE_ALT_IG": {
+      "description": "The site to use as a replacement for instagram.com when site alternatives are enabled in the config."
+      "value": "",
+      "required": false
     }
   }
 }

--- a/app/filter.py
+++ b/app/filter.py
@@ -74,7 +74,8 @@ class Filter:
         footer = soup.find('footer')
         if footer:
             # Remove divs that have multiple links beyond just page navigation
-            [_.decompose() for _ in footer.find_all('div', recursive=False) if len(_.find_all('a', href=True)) > 2]
+            [_.decompose() for _ in footer.find_all('div', recursive=False) 
+                    if len(_.find_all('a', href=True)) > 3]
 
         header = soup.find('header')
         if header:

--- a/app/routes.py
+++ b/app/routes.py
@@ -57,10 +57,12 @@ def before_request_func():
     if session['uuid'] not in app.user_elements:
         app.user_elements.update({session['uuid']: 0})
 
-    # Always redirect to https if HTTPS_ONLY is set (otherwise default to False)
+    # Handle https upgrade
     https_only = os.getenv('HTTPS_ONLY', False)
+    is_heroku = request.url.endswith('.herokuapp.com')
+    is_http = request.url.startswith('http://')
 
-    if https_only and request.url.startswith('http://'):
+    if (is_heroku and is_http) or (https_only and is_http):
         return redirect(request.url.replace('http://', 'https://', 1), code=308)
 
     g.user_config = Config(**session['config'])

--- a/app/utils/filter_utils.py
+++ b/app/utils/filter_utils.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+import os
 import urllib.parse as urlparse
 from urllib.parse import parse_qs
 
@@ -17,9 +18,9 @@ BLACKLIST = [
 ]
 
 SITE_ALTS = {
-    'twitter.com': 'nitter.net',
-    'youtube.com': 'invidious.snopyta.org',
-    'instagram.com': 'bibliogram.art/u'
+    'twitter.com': os.getenv('WHOOGLE_ALT_TW', 'nitter.net'),
+    'youtube.com': os.getenv('WHOOGLE_ALT_YT', 'invidious.snopyta.org'),
+    'instagram.com': os.getenv('WHOOGLE_ALT_IG', 'bibliogram.art/u')
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       #- WHOOGLE_PROXY_PASS=<proxy password>
       #- WHOOGLE_PROXY_TYPE=<proxy type (http|socks4|socks5)
       #- WHOOGLE_PROXY_LOC=<proxy host/ip>
+      # Site alternative configurations, uncomment to enable
+      # Note: If not set, the feature will still be available
+      # with default values. 
+      #- WHOOGLE_ALT_TW=nitter.net
+      #- WHOOGLE_ALT_YT=invidious.snopyta.org
+      #- WHOOGLE_ALT_IG=bibliogram.art/u
     ports:
       - 5000:5000
     restart: unless-stopped

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,17 @@
 from app import app
+from app.models.config import Config
 from app.utils.session_utils import generate_user_keys
 import pytest
+import random
+
+demo_config = {
+    'near': random.choice(['Seattle', 'New York', 'San Francisco']),
+    'dark_mode': str(random.getrandbits(1)),
+    'nojs': str(random.getrandbits(1)),
+    'lang_interface': random.choice(Config.LANGUAGES)['value'],
+    'lang_search': random.choice(Config.LANGUAGES)['value'],
+    'ctry': random.choice(Config.COUNTRIES)['value']
+}
 
 
 @pytest.fixture

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -3,6 +3,8 @@ from app.filter import Filter
 from app.utils.session_utils import generate_user_keys
 from datetime import datetime
 from dateutil.parser import *
+import json
+import os
 
 
 def get_search_results(data):
@@ -41,6 +43,18 @@ def test_post_results(client):
     # than 10 result divs
     assert len(get_search_results(rv.data)) >= 10
     assert len(get_search_results(rv.data)) <= 15
+
+
+def test_site_alts(client):
+    rv = client.post('/search', data=dict(q='twitter official account'))
+    assert b'twitter.com/Twitter' in rv.data
+
+    client.post('/config', data=dict(alts=True))
+    assert json.loads(client.get('/config').data)['alts']
+
+    rv = client.post('/search', data=dict(q='twitter official account'))
+    assert b'twitter.com/Twitter' not in rv.data
+    assert b'nitter.net/Twitter' in rv.data
 
 
 def test_recent_results(client):

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,15 +1,6 @@
-from app.models.config import Config
 import json
-import random
 
-demo_config = {
-    'near': random.choice(['Seattle', 'New York', 'San Francisco']),
-    'dark_mode': str(random.getrandbits(1)),
-    'nojs': str(random.getrandbits(1)),
-    'lang_interface': random.choice(Config.LANGUAGES)['value'],
-    'lang_search': random.choice(Config.LANGUAGES)['value'],
-    'ctry': random.choice(Config.COUNTRIES)['value']
-}
+from test.conftest import demo_config
 
 
 def test_main(client):
@@ -58,4 +49,4 @@ def test_config(client):
 def test_opensearch(client):
     rv = client.get('/opensearch.xml')
     assert rv._status_code == 200
-    assert 'Whoogle' in str(rv.data)
+    assert '<ShortName>Whoogle</ShortName>' in str(rv.data)


### PR DESCRIPTION
Heroku app instances have been notoriously bad at having the instance
automatically upgraded to https. This adds a step in the before request
decorator to always upgrade heroku apps, since they're always deployed
with the certificate, but never configured to upgrade automatically.

Fixes #153