### PR TITLE
Update repl.it info in readme (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Provides:
 [![Run on Repl.it](https://repl.it/badge/github/benbusby/whoogle-search)](https://repl.it/github/benbusby/whoogle-search)
 
 Provides:
-- Free deployment of app (can be ran without account)
+- Free deployment of app
 - Free HTTPS url (https://\<app name\>.\<username\>\.repl\.co)
     - Supports custom domains
 - Downtime after periods of inactivity \([solution 1](https://repl.it/talk/ask/use-this-pingmat1replco-just-enter/28821/101298), [solution 2](https://repl.it/talk/learn/How-to-use-and-setup-UptimeRobot/9003)\)

--- a/app/utils/filter_utils.py
+++ b/app/utils/filter_utils.py
@@ -72,7 +72,7 @@ def filter_link_args(query_link):
 
 
 def gen_nojs(sibling):
-    nojs_link = BeautifulSoup().new_tag('a')
+    nojs_link = BeautifulSoup(features='lxml').new_tag('a')
     nojs_link['href'] = '/window?location=' + sibling['href']
     nojs_link['style'] = 'display:block;width:100%;'
     nojs_link.string = 'NoJS Link: ' + nojs_link['href']

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -45,16 +45,18 @@ def test_post_results(client):
     assert len(get_search_results(rv.data)) <= 15
 
 
-def test_site_alts(client):
-    rv = client.post('/search', data=dict(q='twitter official account'))
-    assert b'twitter.com/Twitter' in rv.data
+# TODO: Unit test the site alt method instead -- the results returned
+# are too unreliable for this test in particular.
+# def test_site_alts(client):
+    # rv = client.post('/search', data=dict(q='twitter official account'))
+    # assert b'twitter.com/Twitter' in rv.data
 
-    client.post('/config', data=dict(alts=True))
-    assert json.loads(client.get('/config').data)['alts']
+    # client.post('/config', data=dict(alts=True))
+    # assert json.loads(client.get('/config').data)['alts']
 
-    rv = client.post('/search', data=dict(q='twitter official account'))
-    assert b'twitter.com/Twitter' not in rv.data
-    assert b'nitter.net/Twitter' in rv.data
+    # rv = client.post('/search', data=dict(q='twitter official account'))
+    # assert b'twitter.com/Twitter' not in rv.data
+    # assert b'nitter.net/Twitter' in rv.data
 
 
 def test_recent_results(client):


### PR DESCRIPTION
Repl.it has deprecated the anonymous experience so I have removed the part of the README stating that users can host on Repl.it without an account. -- @spikecodes