### PR TITLE
Add docker buildx gh action

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -1,0 +1,26 @@
+name: buildx
+
+on:
+  push:
+    branches: develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      - name: log in to docker hub
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | \
+            docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build and push the image
+        run: |
+          docker buildx build --push \
+            --tag benbusby/whoogle-search:buildx-experimental \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     libcurl4-openssl-dev \
     libssl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev \
     tor
 
 COPY misc/tor/torrc /etc/tor/torrc

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ sudo systemctl start whoogle
 2. Clone and deploy the docker app using a method below:
 
 #### Docker CLI
+
+***Note:** For ARM machines, use the `buildx-experimental` Docker tag.*
+
 Through Docker Hub:
 ```bash
 docker pull benbusby/whoogle-search


### PR DESCRIPTION
This automatically builds and pushes a cross platform image to Docker
Hub.