### PR TITLE
Hotfix: Add hidden submit btn for nojs searches

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -15,6 +15,7 @@
                                        border: {{ '1px solid #685e79' if dark_mode else '' }}"
                                spellcheck="false" type="text" value="{{ query }}">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
+                        <input type="submit" style="display: none;">
                         <div class="sc"></div>
                     </div>
                 </div>
@@ -38,6 +39,7 @@
                                        color: {{ '#685e79' if dark_mode else '#000' }};
                                        border: {{ '1px solid #685e79' if dark_mode else '' }}">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
+                        <input type="submit" style="display: none;">
                         <div class="sc"></div>
                     </div>
                 </div>


### PR DESCRIPTION
With javascript disabled, searches could not be submitted on the results
page using the "Enter" key. Adding a hidden submit button to the header
template resolves this issue.