### PR TITLE
Hotfix: Enforce https in heroku opensearch template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ ARG youtube_alt='invidious.snopyta.org'
 ENV WHOOGLE_ALT_YT=$youtube_alt
 ARG instagram_alt='bibliogram.art/u'
 ENV WHOOGLE_ALT_YT=$instagram_alt
+ARG reddit_alt='libredd.it'
+ENV WHOOGLE_ALT_RD=$reddit_alt
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Description=Whoogle
 #Environment=WHOOGLE_ALT_TW=nitter.net
 #Environment=WHOOGLE_ALT_YT=invidious.snopyta.org
 #Environment=WHOOGLE_ALT_IG=bibliogram.art/u
+#Environment=WHOOGLE_ALT_RD=libredd.it
 Type=simple
 User=root
 WorkingDirectory=<whoogle_directory>

--- a/app.json
+++ b/app.json
@@ -47,17 +47,22 @@
     },
     "WHOOGLE_ALT_TW": {
       "description": "The site to use as a replacement for twitter.com when site alternatives are enabled in the config.",
-      "value": "",
+      "value": "nitter.net",
       "required": false
     },
     "WHOOGLE_ALT_YT": {
       "description": "The site to use as a replacement for youtube.com when site alternatives are enabled in the config.",
-      "value": "",
+      "value": "invidious.snopyta.org",
       "required": false
     },
     "WHOOGLE_ALT_IG": {
       "description": "The site to use as a replacement for instagram.com when site alternatives are enabled in the config.",
-      "value": "",
+      "value": "bibliogram.art/u",
+      "required": false
+    },
+    "WHOOGLE_ALT_RD": {
+      "description": "The site to use as a replacement for reddit.com when site alternatives are enabled in the config.",
+      "value": "libredd.it",
       "required": false
     }
   }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -116,8 +116,8 @@
                         <div class="config-div">
                             <label class="tooltip" for="config-alts">Replace Social Media Links: </label>
                             <input type="checkbox" name="alts" id="config-alts">
-                            <div><span class="info-text"> — Replaces Twitter/YouTube/Instagram links
-                                with Nitter/Invidious/Bibliogram links.</span></div>
+                            <div><span class="info-text"> — Replaces Twitter/YouTube/Instagram/Reddit links
+                                with Nitter/Invidious/Bibliogram/Libreddit links.</span></div>
                         </div>
                         <div class="config-div">
                             <label for="config-new-tab">Open Links in New Tab: </label>

--- a/app/utils/filter_utils.py
+++ b/app/utils/filter_utils.py
@@ -4,6 +4,7 @@ import urllib.parse as urlparse
 from urllib.parse import parse_qs
 
 SKIP_ARGS = ['ref_src', 'utm']
+SKIP_PREFIX = ['//www.', '//mobile.', '//m.']
 FULL_RES_IMG = '<br/><a href="{}">Full Image</a>'
 GOOG_IMG = '/images/branding/searchlogo/1x/googlelogo'
 LOGO_URL = GOOG_IMG + '_desk'
@@ -22,7 +23,8 @@ BLACKLIST = [
 SITE_ALTS = {
     'twitter.com': os.getenv('WHOOGLE_ALT_TW', 'nitter.net'),
     'youtube.com': os.getenv('WHOOGLE_ALT_YT', 'invidious.snopyta.org'),
-    'instagram.com': os.getenv('WHOOGLE_ALT_IG', 'bibliogram.art/u')
+    'instagram.com': os.getenv('WHOOGLE_ALT_IG', 'bibliogram.art/u'),
+    'reddit.com': os.getenv('WHOOGLE_ALT_RD', 'libredd.it')
 }
 
 
@@ -47,7 +49,10 @@ def get_site_alt(link: str):
         link = link.replace(site_key, SITE_ALTS[site_key])
         break
 
-    return link.replace('www.', '').replace('//m.', '//')
+    for prefix in SKIP_PREFIX:
+        link = link.replace(prefix, '//')
+
+    return link
 
 
 def filter_link_args(query_link):

--- a/app/utils/routing_utils.py
+++ b/app/utils/routing_utils.py
@@ -5,8 +5,17 @@ from bs4 import BeautifulSoup as bsoup
 from cryptography.fernet import Fernet, InvalidToken
 from flask import g
 from typing import Any, Tuple
+import os
 
 TOR_BANNER = '<hr><h1 style="text-align: center">You are using Tor</h1><hr>'
+
+
+def needs_https(url: str) -> bool:
+    https_only = os.getenv('HTTPS_ONLY', False)
+    is_heroku = url.endswith('.herokuapp.com')
+    is_http = url.startswith('http://')
+
+    return (is_heroku and is_http) or (https_only and is_http)
 
 
 class RoutingUtils:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       #- WHOOGLE_ALT_TW=nitter.net
       #- WHOOGLE_ALT_YT=invidious.snopyta.org
       #- WHOOGLE_ALT_IG=bibliogram.art/u
+      #- WHOOGLE_ALT_RD=libredd.it
     ports:
       - 5000:5000
     restart: unless-stopped


### PR DESCRIPTION
Heroku instances were using the base http url when formatting the
opensearch.xml template. This adds a new routing utility, "needs_https",
which can be used for determining if the url in question needs
upgrading.