### PR TITLE
Remove public instance from readme

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -21,6 +21,8 @@ jobs:
             docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: build and push the image
         run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx ls
           docker buildx build --push \
             --tag benbusby/whoogle-search:buildx-experimental \
             --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ENV WHOOGLE_PROXY_TYPE=$proxytype
 ARG proxyloc=''
 ENV WHOOGLE_PROXY_LOC=$proxyloc
 
+ARG whoogle_dotenv=''
+ENV WHOOGLE_DOTENV=$whoogle_dotenv
+
 ARG use_https=''
 ENV HTTPS_ONLY=$use_https
 
@@ -59,6 +62,7 @@ COPY misc/tor/torrc /etc/tor/torrc
 COPY misc/tor/start-tor.sh misc/tor/start-tor.sh
 COPY app/ app/
 COPY run .
+COPY whoogle.env .
 
 EXPOSE $EXPOSE_PORT
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,6 @@ A lot of the app currently piggybacks on Google's existing support for fetching 
 *Note: Use public instances at your own discretion. Maintainers of Whoogle do not personally validate the integrity of these instances, and popular public instances are more likely to be rate-limited or blocked.*
 
 - [https://whoogle.sdf.org](https://whoogle.sdf.org)
-- [https://whoogle.tormentasolar.win/](https://whoogle.tormentasolar.win/)
 - [https://whoogle.himiko.cloud](https://whoogle.himiko.cloud)
 - [https://whoogle.kavin.rocks](https://whoogle.kavin.rocks) or [http://whoogledq5f5wly5p4i2ohnvjwlihnlg4oajjum2oeddfwqdwupbuhqd.onion](http://whoogledq5f5wly5p4i2ohnvjwlihnlg4oajjum2oeddfwqdwupbuhqd.onion)
 

--- a/README.md
+++ b/README.md
@@ -237,21 +237,37 @@ Depending on your preferences, you can also deploy the app yourself on your own 
 ## Environment Variables
 There are a few optional environment variables available for customizing a Whoogle instance. These can be set manually, or copied into `whoogle.env` and enabled by setting `WHOOGLE_DOTENV=1`.
 
-| Variable           | Description                                                    |
-| ------------------ | -------------------------------------------------------------- |
-| WHOOGLE_DOTENV     | Load environment variables in `whoogle.env`                    |
-| WHOOGLE_USER       | The username for basic auth. WHOOGLE_PASS must also be set if used. |
-| WHOOGLE_PASS       | The password for basic auth. WHOOGLE_USER must also be set if used. |
-| WHOOGLE_PROXY_USER | The username of the proxy server.                              |
-| WHOOGLE_PROXY_PASS | The password of the proxy server.                              |
-| WHOOGLE_PROXY_TYPE | The type of the proxy server. Can be "socks5", "socks4", or "http".           |
-| WHOOGLE_PROXY_LOC  | The location of the proxy server (host or ip).                 |
-| EXPOSE_PORT        | The port where Whoogle will be exposed.                        |
+| Variable           | Description                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| WHOOGLE_DOTENV     | Load environment variables in `whoogle.env`                                               |
+| WHOOGLE_USER       | The username for basic auth. WHOOGLE_PASS must also be set if used.                       |
+| WHOOGLE_PASS       | The password for basic auth. WHOOGLE_USER must also be set if used.                       |
+| WHOOGLE_PROXY_USER | The username of the proxy server.                                                         |
+| WHOOGLE_PROXY_PASS | The password of the proxy server.                                                         |
+| WHOOGLE_PROXY_TYPE | The type of the proxy server. Can be "socks5", "socks4", or "http".                       |
+| WHOOGLE_PROXY_LOC  | The location of the proxy server (host or ip).                                            |
+| EXPOSE_PORT        | The port where Whoogle will be exposed.                                                   |
 | HTTPS_ONLY         | Enforce HTTPS. (See [here](https://github.com/benbusby/whoogle-search#https-enforcement)) |
-| WHOOGLE_ALT_TW     | The twitter.com alternative to use when site alternatives are enabled in the config. |
-| WHOOGLE_ALT_YT     | The youtube.com alternative to use when site alternatives are enabled in the config. |
-| WHOOGLE_ALT_IG     | The instagram.com alternative to use when site alternatives are enabled in the config. |
-| WHOOGLE_ALT_RD     | The reddit.com alternative to use when site alternatives are enabled in the config. |
+| WHOOGLE_ALT_TW     | The twitter.com alternative to use when site alternatives are enabled in the config.      |
+| WHOOGLE_ALT_YT     | The youtube.com alternative to use when site alternatives are enabled in the config.      |
+| WHOOGLE_ALT_IG     | The instagram.com alternative to use when site alternatives are enabled in the config.    |
+| WHOOGLE_ALT_RD     | The reddit.com alternative to use when site alternatives are enabled in the config.       |
+
+### Config Environment Variables
+These environment variables allow setting default config values, but can be overwritten manually by using the home page config menu. These allow a shortcut for destroying/rebuilding an instance to the same config state every time.
+
+| Variable                | Description                                                     |
+| ----------------------- | --------------------------------------------------------------- |
+| WHOOGLE_CONFIG_COUNTRY  | Filter results by hosting country                               |
+| WHOOGLE_CONFIG_LANGUAGE | Set interface and search result language                        |
+| WHOOGLE_CONFIG_DARK     | Enable dark theme                                               |
+| WHOOGLE_CONFIG_SAFE     | Enable safe searches                                            |
+| WHOOGLE_CONFIG_ALTS     | Use social media site alternatives (nitter, invidious, etc)     |
+| WHOOGLE_CONFIG_TOR      | Use Tor routing (if available)                                  |
+| WHOOGLE_CONFIG_NEW_TAB  | Always open results in new tab                                  |
+| WHOOGLE_CONFIG_GET_ONLY | Search using GET requests only                                  |
+| WHOOGLE_CONFIG_URL      | The root url of the instance (`https://<your url>/`)            |
+| WHOOGLE_CONFIG_STYLE    | The custom CSS to use for styling (must be single line)         |
 
 ## Usage
 Same as most search engines, with the exception of filtering by time range.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Description=Whoogle
 #Environment=WHOOGLE_ALT_YT=invidious.snopyta.org
 #Environment=WHOOGLE_ALT_IG=bibliogram.art/u
 #Environment=WHOOGLE_ALT_RD=libredd.it
+# Load values from dotenv only
+#Environment=WHOOGLE_DOTENV=1
 Type=simple
 User=root
 WorkingDirectory=<whoogle_directory>
@@ -233,10 +235,11 @@ Depending on your preferences, you can also deploy the app yourself on your own 
   - A bit more experience or willingness to work through issues
 
 ## Environment Variables
-There are a few optional environment variables available for customizing a Whoogle instance:
+There are a few optional environment variables available for customizing a Whoogle instance. These can be set manually, or copied into `whoogle.env` and enabled by setting `WHOOGLE_DOTENV=1`.
 
 | Variable           | Description                                                    |
 | ------------------ | -------------------------------------------------------------- |
+| WHOOGLE_DOTENV     | Load environment variables in `whoogle.env`                    |
 | WHOOGLE_USER       | The username for basic auth. WHOOGLE_PASS must also be set if used. |
 | WHOOGLE_PASS       | The password for basic auth. WHOOGLE_USER must also be set if used. |
 | WHOOGLE_PROXY_USER | The username of the proxy server.                              |

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ A lot of the app currently piggybacks on Google's existing support for fetching 
 - [https://whoogle.sdf.org](https://whoogle.sdf.org)
 - [https://whoogle.himiko.cloud](https://whoogle.himiko.cloud)
 - [https://whoogle.kavin.rocks](https://whoogle.kavin.rocks) or [http://whoogledq5f5wly5p4i2ohnvjwlihnlg4oajjum2oeddfwqdwupbuhqd.onion](http://whoogledq5f5wly5p4i2ohnvjwlihnlg4oajjum2oeddfwqdwupbuhqd.onion)
+- [https://search.garudalinux.org](https://search.garudalinux.org)
 
 ## Screenshots
 #### Desktop

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,9 +6,17 @@ from flask_session import Session
 import json
 import os
 from stem import Signal
+from dotenv import load_dotenv
 
 app = Flask(__name__, static_folder=os.path.dirname(
     os.path.abspath(__file__)) + '/static')
+
+# Load .env file if enabled
+if os.getenv("WHOOGLE_DOTENV", ''):
+    dotenv_path = '../whoogle.env'
+    load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             dotenv_path))
+
 app.user_elements = {}
 app.default_key_set = generate_user_keys()
 app.no_cookie_ips = []

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -5,20 +5,20 @@ import os
 class Config:
     def __init__(self, **kwargs):
         app_config = current_app.config
-        self.url = ''
-        self.lang_search = ''
-        self.lang_interface = ''
+        self.url = os.getenv('WHOOGLE_CONFIG_URL', '')
+        self.lang_search = os.getenv('WHOOGLE_CONFIG_LANGUAGE', '')
+        self.lang_interface = os.getenv('WHOOGLE_CONFIG_LANGUAGE', '')
         self.style = open(os.path.join(app_config['STATIC_FOLDER'],
                                        'css/variables.css')).read()
-        self.ctry = ''
-        self.safe = False
-        self.dark = False
-        self.nojs = False
-        self.tor = False
-        self.near = ''
-        self.alts = False
-        self.new_tab = False
-        self.get_only = False
+        self.ctry = os.getenv('WHOOGLE_CONFIG_COUNTRY', '')
+        self.safe = bool(os.getenv('WHOOGLE_CONFIG_SAFE', False))
+        self.dark = bool(os.getenv('WHOOGLE_CONFIG_DARK', False))
+        self.alts = bool(os.getenv('WHOOGLE_CONFIG_ALTS', False))
+        self.nojs = bool(os.getenv('WHOOGLE_CONFIG_NOJS', False))
+        self.tor = bool(os.getenv('WHOOGLE_CONFIG_TOR', False))
+        self.near = os.getenv('WHOOGLE_CONFIG_NEAR', '')
+        self.new_tab = bool(os.getenv('WHOOGLE_CONFIG_NEW_TAB', False))
+        self.get_only = bool(os.getenv('WHOOGLE_CONFIG_GET_ONLY', False))
         self.safe_keys = [
             'lang_search',
             'lang_interface',
@@ -27,6 +27,8 @@ class Config:
         ]
 
         for key, value in kwargs.items():
+            if not value:
+                continue
             setattr(self, key, value)
 
     def __getitem__(self, name):

--- a/app/routes.py
+++ b/app/routes.py
@@ -54,8 +54,7 @@ def before_request_func():
     # Generate session values for user if unavailable
     if not valid_user_session(session):
         session['config'] = json.load(open(app.config['DEFAULT_CONFIG'])) \
-            if os.path.exists(app.config['DEFAULT_CONFIG']) else {
-            'url': request.url_root}
+            if os.path.exists(app.config['DEFAULT_CONFIG']) else {}
         session['uuid'] = str(uuid.uuid4())
         session['fernet_keys'] = generate_user_keys(True)
 

--- a/app/utils/results.py
+++ b/app/utils/results.py
@@ -3,6 +3,7 @@ import os
 import urllib.parse as urlparse
 from urllib.parse import parse_qs
 
+
 SKIP_ARGS = ['ref_src', 'utm']
 SKIP_PREFIX = ['//www.', '//mobile.', '//m.']
 GOOG_STATIC = 'www.gstatic.com'
@@ -11,6 +12,7 @@ LOGO_URL = GOOG_IMG + '_desk'
 BLANK_B64 = ('data:image/png;base64,'
              'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAQAAAAnOwc2AAAAD0lEQVR42mNkw'
              'AIYh7IgAAVVAAuInjI5AAAAAElFTkSuQmCC')
+
 
 # Ad keywords
 BLACKLIST = [
@@ -70,6 +72,7 @@ def get_site_alt(link: str) -> str:
         str: An updated (or ignored) result link
 
     """
+
     for site_key in SITE_ALTS.keys():
         if site_key not in link:
             continue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       #- WHOOGLE_ALT_YT=invidious.snopyta.org
       #- WHOOGLE_ALT_IG=bibliogram.art/u
       #- WHOOGLE_ALT_RD=libredd.it
+      # Load environment variables from whoogle.env
+      #- WHOOGLE_DOTENV=1
     ports:
       - 5000:5000
     restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ urllib3==1.25.9
 waitress==1.4.3
 wcwidth==0.1.9
 Werkzeug==0.16.0
+python-dotenv==0.16.0

--- a/run
+++ b/run
@@ -22,5 +22,5 @@ else
     mkdir -p "$STATIC_FOLDER"
     python3 -um app \
       --host "${ADDRESS:-0.0.0.0}" \
-      --port "${PORT:-"${EXPOSE_PORT:-5000}"}" --debug
+      --port "${PORT:-"${EXPOSE_PORT:-5000}"}"
 fi

--- a/run
+++ b/run
@@ -22,5 +22,5 @@ else
     mkdir -p "$STATIC_FOLDER"
     python3 -um app \
       --host "${ADDRESS:-0.0.0.0}" \
-      --port "${PORT:-"${EXPOSE_PORT:-5000}"}"
+      --port "${PORT:-"${EXPOSE_PORT:-5000}"}" --debug
 fi

--- a/whoogle.env
+++ b/whoogle.env
@@ -1,0 +1,14 @@
+# You can set Whoogle environment variables here, but must set
+# WHOOGLE_DOTENV=1 in your deployment to enable these values
+
+#WHOOGLE_ALT_TW=nitter.net
+#WHOOGLE_ALT_YT=invidious.snopyta.org
+#WHOOGLE_ALT_IG=bibliogram.art/u
+#WHOOGLE_ALT_RD=libredd.it
+#WHOOGLE_USER=""
+#WHOOGLE_PASS=""
+#WHOOGLE_PROXY_USER=""
+#WHOOGLE_PROXY_PASS=""
+#WHOOGLE_PROXY_TYPE=""
+#WHOOGLE_PROXY_LOC=""
+#HTTPS_ONLY=1

--- a/whoogle.env
+++ b/whoogle.env
@@ -12,3 +12,14 @@
 #WHOOGLE_PROXY_TYPE=""
 #WHOOGLE_PROXY_LOC=""
 #HTTPS_ONLY=1
+
+#WHOOGLE_CONFIG_COUNTRY=countryUK  # See app/static/settings/countries.json for values
+#WHOOGLE_CONFIG_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
+#WHOOGLE_CONFIG_DARK=1  # Dark mode
+#WHOOGLE_CONFIG_SAFE=1  # Safe searches
+#WHOOGLE_CONFIG_ALTS=1  # Use social media site alternatives
+#WHOOGLE_CONFIG_TOR=1   # Use Tor if available
+#WHOOGLE_CONFIG_NEW_TAB=1  # Open results in new tab
+#WHOOGLE_CONFIG_GET_ONLY=1 # Search using GET requests only
+#WHOOGLE_CONFIG_URL=https://<whoogle url>/
+#WHOOGLE_CONFIG_STYLE=":root { /* LIGHT THEME COLORS */ --whoogle-background: #d8dee9; --whoogle-accent: #2e3440; --whoogle-text: #3B4252; --whoogle-contrast-text: #eceff4; --whoogle-secondary-text: #70757a; --whoogle-result-bg: #fff; --whoogle-result-title: #4c566a; --whoogle-result-url: #81a1c1; --whoogle-result-visited: #a3be8c; /* DARK THEME COLORS */ --whoogle-dark-background: #222; --whoogle-dark-accent: #685e79; --whoogle-dark-text: #fff; --whoogle-dark-contrast-text: #000; --whoogle-dark-secondary-text: #bbb; --whoogle-dark-result-bg: #000; --whoogle-dark-result-title: #1967d2; --whoogle-dark-result-url: #4b11a8; --whoogle-dark-result-visited: #bbbbff; }"


### PR DESCRIPTION
I've received multiple reports that the Whoogle instance hosted at 
whoogle.tormentasolar.win is spam, so it has been removed from the
readme.