### PR TITLE
Hotfix: Send generic "Mozilla" in user agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,6 @@ COPY whoogle.env .
 EXPOSE $EXPOSE_PORT
 
 HEALTHCHECK  --interval=30s --timeout=5s \
-  CMD wget --no-verbose --tries=1 http://localhost:${EXPOSE_PORT}/ || exit 1
+  CMD wget -qO- --no-verbose --tries=1 http://localhost:${EXPOSE_PORT}/ || exit 1
 
 CMD misc/tor/start-tor.sh & ./run

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from app.utils.bangs import gen_bangs_json
 from flask import Flask
 from flask_session import Session
 import json
+import logging.config
 import os
 from stem import Signal
 from dotenv import load_dotenv
@@ -74,3 +75,9 @@ Session(app)
 send_tor_signal(Signal.HEARTBEAT)
 
 from app import routes  # noqa
+
+# Disable logging from imported modules
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': True,
+})

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,7 @@ app.default_key = generate_user_key()
 app.no_cookie_ips = []
 app.config['SECRET_KEY'] = os.urandom(32)
 app.config['SESSION_TYPE'] = 'filesystem'
-app.config['VERSION_NUMBER'] = '0.4.0'
+app.config['VERSION_NUMBER'] = '0.4.1'
 app.config['APP_ROOT'] = os.getenv(
     'APP_ROOT',
     os.path.dirname(os.path.abspath(__file__)))

--- a/app/filter.py
+++ b/app/filter.py
@@ -153,7 +153,9 @@ class Filter:
 
         if src.startswith(LOGO_URL):
             # Re-brand with Whoogle logo
-            element.replace_with(BeautifulSoup(render_template('logo.html')))
+            element.replace_with(BeautifulSoup(
+                render_template('logo.html', dark=self.dark),
+                features='html.parser'))
             return
         elif src.startswith(GOOG_IMG) or GOOG_STATIC in src:
             element['src'] = BLANK_B64
@@ -164,7 +166,6 @@ class Filter:
             is_element=True) + '&type=' + urlparse.quote(mime)
 
     def update_styling(self, soup) -> None:
-        """"""
         # Remove unnecessary button(s)
         for button in soup.find_all('button'):
             button.decompose()

--- a/app/request.py
+++ b/app/request.py
@@ -49,14 +49,13 @@ def send_tor_signal(signal: Signal) -> bool:
 
 
 def gen_user_agent(is_mobile) -> str:
-    mozilla = random.choice(['Moo', 'Woah', 'Bro', 'Slow']) + 'zilla'
     firefox = random.choice(['Choir', 'Squier', 'Higher', 'Wire']) + 'fox'
     linux = random.choice(['Win', 'Sin', 'Gin', 'Fin', 'Kin']) + 'ux'
 
     if is_mobile:
-        return MOBILE_UA.format(mozilla, firefox)
+        return MOBILE_UA.format("Mozilla", firefox)
 
-    return DESKTOP_UA.format(mozilla, linux, firefox)
+    return DESKTOP_UA.format("Mozilla", linux, firefox)
 
 
 def gen_query(query, args, config, near_city=None) -> str:

--- a/app/routes.py
+++ b/app/routes.py
@@ -128,7 +128,7 @@ def index():
                            countries=app.config['COUNTRIES'],
                            logo=render_template(
                                'logo.html',
-                               config=g.user_config),
+                               dark=g.user_config.dark),
                            config=g.user_config,
                            tor_available=int(os.environ.get('TOR_AVAILABLE')),
                            version_number=app.config['VERSION_NUMBER'])
@@ -227,7 +227,7 @@ def search():
         search_header=(render_template(
             'header.html',
             config=g.user_config,
-            logo=render_template('logo.html'),
+            logo=render_template('logo.html', dark=g.user_config.dark),
             query=urlparse.unquote(query),
             search_type=search_util.search_type,
             mobile=g.user_request.mobile)

--- a/app/static/css/dark-theme.css
+++ b/app/static/css/dark-theme.css
@@ -86,11 +86,11 @@ select {
 }
 
 .collapsible {
-    color: var(--whoogle-dark-element-bg) !important;
+    color: var(--whoogle-dark-text);
 }
 
 .collapsible:after {
-    color: var(--whoogle-dark-element-bg) !important;
+    color: var(--whoogle-dark-text);
 }
 
 .active {
@@ -104,11 +104,11 @@ select {
 }
 
 .active:after {
-    color: var(--whoogle-dark-contrast-text);
+    color: var(--whoogle-dark-contrast-text) !important;
 }
 
 #gh-link {
-    color: var(--whoogle-dark-element-bg);
+    color: var(--whoogle-dark-contrast-text);
 }
 
 .autocomplete-items {

--- a/app/static/css/light-theme.css
+++ b/app/static/css/light-theme.css
@@ -86,11 +86,11 @@ input {
 }
 
 .collapsible {
-    color: var(--whoogle-element-bg) !important;
+    color: var(--whoogle-text) !important;
 }
 
 .collapsible:after {
-    color: var(--whoogle-element-bg) !important;
+    color: var(--whoogle-text);
 }
 
 .active {

--- a/app/static/css/variables.css
+++ b/app/static/css/variables.css
@@ -13,14 +13,14 @@
     --whoogle-result-visited: #4b11a8;
 
     /* DARK THEME COLORS */
-    --whoogle-dark-logo: #685e79;
-    --whoogle-dark-page-bg: #222222;
-    --whoogle-dark-element-bg: #685e79;
-    --whoogle-dark-text: #ffffff;
-    --whoogle-dark-contrast-text: #000000;
-    --whoogle-dark-secondary-text: #bbbbbb;
-    --whoogle-dark-result-bg: #000000;
-    --whoogle-dark-result-title: #1967d2;
-    --whoogle-dark-result-url: #4b11a8;
-    --whoogle-dark-result-visited: #bbbbff;
+    --whoogle-dark-logo: #888888;
+    --whoogle-dark-page-bg: #080808;
+    --whoogle-dark-element-bg: #111111;
+    --whoogle-dark-text: #dddddd;
+    --whoogle-dark-contrast-text: #aaaaaa;
+    --whoogle-dark-secondary-text: #8a8b8c;
+    --whoogle-dark-result-bg: #111111;
+    --whoogle-dark-result-title: #dddddd;
+    --whoogle-dark-result-url: #eceff4;
+    --whoogle-dark-result-visited: #959595;
 }

--- a/app/templates/display.html
+++ b/app/templates/display.html
@@ -17,9 +17,9 @@
     {{ response|safe }}
     </body>
     <footer>
-        <p style="color: {{ '#fff' if config.dark else '#000' }};">
+        <p style="color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};">
             Whoogle Search v{{ version_number }} ||
-            <a style="color: #685e79" href="https://github.com/benbusby/whoogle-search">View on GitHub</a>
+            <a id="gh-link" href="https://github.com/benbusby/whoogle-search">View on GitHub</a>
         </p>
     </footer>
 	<script src="static/js/autocomplete.js"></script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -144,10 +144,10 @@
             </div>
         </div>
         <footer>
-            <p style="color: {{ '#fff' if config.dark else '#000' }};">
-                Whoogle Search v{{ version_number }} ||
-                <a id="gh-link" href="https://github.com/benbusby/whoogle-search">View on GitHub</a>
-            </p>
+			<p style="color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};">
+				Whoogle Search v{{ version_number }} ||
+				<a id="gh-link" href="https://github.com/benbusby/whoogle-search">View on GitHub</a>
+			</p>
         </footer>
     </body>
 </html>

--- a/app/templates/logo.html
+++ b/app/templates/logo.html
@@ -2,7 +2,7 @@
     <svg id="Layer_1" class="whoogle-svg" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1028 254">
         <style>
             path {
-                fill: {{ 'var(--whoogle-dark-logo)' if config.dark else 'var(--whoogle-logo)' }};
+                fill: {{ 'var(--whoogle-dark-logo)' if dark else 'var(--whoogle-logo)' }};
             }
         </style>
         <defs>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     author='Ben Busby',
     author_email='benbusby@protonmail.com',
     name='whoogle-search',
-    version='0.4.0',
+    version='0.4.1',
     include_package_data=True,
     install_requires=requirements,
     description='Self-hosted, ad-free, privacy-respecting metasearch engine',


### PR DESCRIPTION
Randomizing the "Mozilla" portion of the user agent changed the
character encoding to GB2312. Setting it to plain "Mozilla" enforces
UTF-8 encoding.

Bump to version 0.4.1 for release of bug fix

Fixes #267