### PR TITLE
Separate interface language from search language in env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,18 +258,19 @@ There are a few optional environment variables available for customizing a Whoog
 ### Config Environment Variables
 These environment variables allow setting default config values, but can be overwritten manually by using the home page config menu. These allow a shortcut for destroying/rebuilding an instance to the same config state every time.
 
-| Variable                | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| WHOOGLE_CONFIG_COUNTRY  | Filter results by hosting country                               |
-| WHOOGLE_CONFIG_LANGUAGE | Set interface and search result language                        |
-| WHOOGLE_CONFIG_DARK     | Enable dark theme                                               |
-| WHOOGLE_CONFIG_SAFE     | Enable safe searches                                            |
-| WHOOGLE_CONFIG_ALTS     | Use social media site alternatives (nitter, invidious, etc)     |
-| WHOOGLE_CONFIG_TOR      | Use Tor routing (if available)                                  |
-| WHOOGLE_CONFIG_NEW_TAB  | Always open results in new tab                                  |
-| WHOOGLE_CONFIG_GET_ONLY | Search using GET requests only                                  |
-| WHOOGLE_CONFIG_URL      | The root url of the instance (`https://<your url>/`)            |
-| WHOOGLE_CONFIG_STYLE    | The custom CSS to use for styling (must be single line)         |
+| Variable                       | Description                                                     |
+| ------------------------------ | --------------------------------------------------------------- |
+| WHOOGLE_CONFIG_COUNTRY         | Filter results by hosting country                               |
+| WHOOGLE_CONFIG_LANGUAGE        | Set interface language                                          |
+| WHOOGLE_CONFIG_SEARCH_LANGUAGE | Set search result language                                      |
+| WHOOGLE_CONFIG_DARK            | Enable dark theme                                               |
+| WHOOGLE_CONFIG_SAFE            | Enable safe searches                                            |
+| WHOOGLE_CONFIG_ALTS            | Use social media site alternatives (nitter, invidious, etc)     |
+| WHOOGLE_CONFIG_TOR             | Use Tor routing (if available)                                  |
+| WHOOGLE_CONFIG_NEW_TAB         | Always open results in new tab                                  |
+| WHOOGLE_CONFIG_GET_ONLY        | Search using GET requests only                                  |
+| WHOOGLE_CONFIG_URL             | The root url of the instance (`https://<your url>/`)            |
+| WHOOGLE_CONFIG_STYLE           | The custom CSS to use for styling (should be single line)       |
 
 ## Usage
 Same as most search engines, with the exception of filtering by time range.

--- a/app.json
+++ b/app.json
@@ -80,6 +80,11 @@
         "value": "",
         "required": false
     },
+    "WHOOGLE_CONFIG_DISABLE": {
+        "description": "[CONFIG] Disable ability for client to change config (set to 1 or leave blank)",
+        "value": "",
+        "required": false
+    },
     "WHOOGLE_CONFIG_DARK": {
         "description": "[CONFIG] Enable dark mode (set to 1 or leave blank)",
         "value": "",

--- a/app.json
+++ b/app.json
@@ -71,7 +71,12 @@
         "required": false
     },
     "WHOOGLE_CONFIG_LANGUAGE": {
-        "description": "[CONFIG] The language to use for search results and interface (use values from https://raw.githubusercontent.com/benbusby/whoogle-search/develop/app/static/settings/languages.json)",
+        "description": "[CONFIG] The language to use for the interface (use values from https://raw.githubusercontent.com/benbusby/whoogle-search/develop/app/static/settings/languages.json)",
+        "value": "",
+        "required": false
+    },
+    "WHOOGLE_CONFIG_SEARCH_LANGUAGE": {
+        "description": "[CONFIG] The language to use for search results (use values from https://raw.githubusercontent.com/benbusby/whoogle-search/develop/app/static/settings/languages.json)",
         "value": "",
         "required": false
     },

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,6 +39,7 @@ app.config['CONFIG_PATH'] = os.getenv(
 app.config['DEFAULT_CONFIG'] = os.path.join(
     app.config['CONFIG_PATH'],
     'config.json')
+app.config['CONFIG_DISABLE'] = os.getenv('WHOOGLE_CONFIG_DISABLE', '')
 app.config['SESSION_FILE_DIR'] = os.path.join(
     app.config['CONFIG_PATH'],
     'session')

--- a/app/models/config.py
+++ b/app/models/config.py
@@ -12,7 +12,7 @@ class Config:
 
         app_config = current_app.config
         self.url = os.getenv('WHOOGLE_CONFIG_URL', '')
-        self.lang_search = os.getenv('WHOOGLE_CONFIG_LANGUAGE', '')
+        self.lang_search = os.getenv('WHOOGLE_CONFIG_SEARCH_LANGUAGE', '')
         self.lang_interface = os.getenv('WHOOGLE_CONFIG_LANGUAGE', '')
         self.style = os.getenv(
             'WHOOGLE_CONFIG_STYLE',
@@ -36,11 +36,12 @@ class Config:
 
         # Skip setting custom config if there isn't one
         if kwargs:
-            for attr in self.get_mutable_attrs():
-                if attr not in kwargs.keys():
-                    setattr(self, attr, '')
-                else:
+            mutable_attrs = self.get_mutable_attrs()
+            for attr in mutable_attrs:
+                if attr in kwargs.keys():
                     setattr(self, attr, kwargs[attr])
+                elif attr not in kwargs.keys() and mutable_attrs[attr] == bool:
+                    setattr(self, attr, False)
 
     def __getitem__(self, name):
         return getattr(self, name)
@@ -55,7 +56,7 @@ class Config:
         return hasattr(self, name)
 
     def get_mutable_attrs(self):
-        return {name: attr for name, attr in self.__dict__.items()
+        return {name: type(attr) for name, attr in self.__dict__.items()
                 if not name.startswith("__")
                 and (type(attr) is bool or type(attr) is str)}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -56,111 +56,113 @@
                     <input type="submit" id="search-submit" value="Search">
                 </div>
             </form>
-            <br/>
-            <button id="config-collapsible" class="collapsible">Configuration</button>
-            <div class="content">
-                <div class="config-fields">
-                    <form id="config-form" action="config" method="post">
-                        <div class="config-div config-div-ctry">
-                            <label for="config-ctry">Filter Results by Country: </label>
-                            <select name="ctry" id="config-ctry">
-                                {% for ctry in countries %}
-                                    <option value="{{ ctry.value }}"
-                                            {% if ctry.value in config.ctry %}
-                                            selected
-                                            {% endif %}>
-                                        {{ ctry.name }}
-                                    </option>
-                                {% endfor %}
-                            </select>
-                            <div><span class="info-text"> — Note: If enabled, a website will only appear in the results if it is *hosted* in the selected country.</span></div>
-                        </div>
-                        <div class="config-div config-div-lang">
-                            <label for="config-lang-interface">Interface Language: </label>
-                            <select name="lang_interface" id="config-lang-interface">
-                                {% for lang in languages %}
-                                <option value="{{ lang.value }}"
-                                    {% if lang.value in config.lang_interface %}
-                                        selected
-                                    {% endif %}>
-                                    {{ lang.name }}
-                                </option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="config-div config-div-search-lang">
-                            <label for="config-lang-search">Search Language: </label>
-                            <select name="lang_search" id="config-lang-search">
-                                {% for lang in languages %}
-                                <option value="{{ lang.value }}"
-                                    {% if lang.value in config.lang_search %}
-                                        selected
-                                    {% endif %}>
-                                    {{ lang.name }}
-                                </option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="config-div config-div-near">
-                            <label for="config-near">Near: </label>
-                            <input type="text" name="near" id="config-near" placeholder="City Name" value="{{ config.near }}">
-                        </div>
-                        <div class="config-div config-div-nojs">
-                            <label for="config-nojs">Show NoJS Links: </label>
-                            <input type="checkbox" name="nojs" id="config-nojs" {{ 'checked' if config.nojs else '' }}>
-                        </div>
-                        <div class="config-div config-div-dark">
-                            <label for="config-dark">Dark Mode: </label>
-                            <input type="checkbox" name="dark" id="config-dark" {{ 'checked' if config.dark else '' }}>
-                        </div>
-                        <div class="config-div config-div-safe">
-                            <label for="config-safe">Safe Search: </label>
-                            <input type="checkbox" name="safe" id="config-safe" {{ 'checked' if config.safe else '' }}>
-                        </div>
-                        <div class="config-div config-div-alts">
-                            <label class="tooltip" for="config-alts">Replace Social Media Links: </label>
-                            <input type="checkbox" name="alts" id="config-alts" {{ 'checked' if config.alts else '' }}>
-                            <div><span class="info-text"> — Replaces Twitter/YouTube/Instagram/Reddit links
-                                with Nitter/Invidious/Bibliogram/Libreddit links.</span></div>
-                        </div>
-                        <div class="config-div config-div-new-tab">
-                            <label for="config-new-tab">Open Links in New Tab: </label>
-                            <input type="checkbox" name="new_tab" id="config-new-tab" {{ 'checked' if config.new_tab else '' }}>
-                        </div>
-                        <div class="config-div config-div-tor">
-                            <label for="config-tor">Use Tor: {{ '' if tor_available else 'Unavailable' }}</label>
-                            <input type="checkbox" name="tor" id="config-tor" {{ '' if tor_available else 'hidden' }} {{ 'checked' if config.tor else '' }}>
-                        </div>
-                        <div class="config-div config-div-get-only">
-                            <label for="config-get-only">GET Requests Only: </label>
-                            <input type="checkbox" name="get_only" id="config-get-only" {{ 'checked' if config.get_only else '' }}>
-                        </div>
-                        <div class="config-div config-div-root-url">
-                            <label for="config-url">Root URL: </label>
-                            <input type="text" name="url" id="config-url" value="{{ config.url }}">
-                        </div>
-                        <div class="config-div config-div-custom-css">
-                            <label for="config-style">Custom CSS:</label>
-                            <textarea 
-                                name="style" 
-                                id="config-style"
-                                autocapitalize="off"
-                                autocomplete="off"
-                                spellcheck="false"
-                                autocorrect="off"
-                                value="">
-                                {{ config.style }}
-                            </textarea>
-                        </div>
-                        <div class="config-div">
-                            <input type="submit" id="config-load" value="Load">&nbsp;
-                            <input type="submit" id="config-submit" value="Apply">&nbsp;
-                            <input type="submit" id="config-save" value="Save As...">
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
+	    {% if not config_disabled %}
+		    <br/>
+		    <button id="config-collapsible" class="collapsible">Configuration</button>
+		    <div class="content">
+			<div class="config-fields">
+			    <form id="config-form" action="config" method="post">
+				<div class="config-div config-div-ctry">
+				    <label for="config-ctry">Filter Results by Country: </label>
+				    <select name="ctry" id="config-ctry">
+					{% for ctry in countries %}
+					    <option value="{{ ctry.value }}"
+						    {% if ctry.value in config.ctry %}
+						    selected
+						    {% endif %}>
+						{{ ctry.name }}
+					    </option>
+					{% endfor %}
+				    </select>
+				    <div><span class="info-text"> — Note: If enabled, a website will only appear in the results if it is *hosted* in the selected country.</span></div>
+				</div>
+				<div class="config-div config-div-lang">
+				    <label for="config-lang-interface">Interface Language: </label>
+				    <select name="lang_interface" id="config-lang-interface">
+					{% for lang in languages %}
+					<option value="{{ lang.value }}"
+					    {% if lang.value in config.lang_interface %}
+						selected
+					    {% endif %}>
+					    {{ lang.name }}
+					</option>
+					{% endfor %}
+				    </select>
+				</div>
+				<div class="config-div config-div-search-lang">
+				    <label for="config-lang-search">Search Language: </label>
+				    <select name="lang_search" id="config-lang-search">
+					{% for lang in languages %}
+					<option value="{{ lang.value }}"
+					    {% if lang.value in config.lang_search %}
+						selected
+					    {% endif %}>
+					    {{ lang.name }}
+					</option>
+					{% endfor %}
+				    </select>
+				</div>
+				<div class="config-div config-div-near">
+				    <label for="config-near">Near: </label>
+				    <input type="text" name="near" id="config-near" placeholder="City Name" value="{{ config.near }}">
+				</div>
+				<div class="config-div config-div-nojs">
+				    <label for="config-nojs">Show NoJS Links: </label>
+				    <input type="checkbox" name="nojs" id="config-nojs" {{ 'checked' if config.nojs else '' }}>
+				</div>
+				<div class="config-div config-div-dark">
+				    <label for="config-dark">Dark Mode: </label>
+				    <input type="checkbox" name="dark" id="config-dark" {{ 'checked' if config.dark else '' }}>
+				</div>
+				<div class="config-div config-div-safe">
+				    <label for="config-safe">Safe Search: </label>
+				    <input type="checkbox" name="safe" id="config-safe" {{ 'checked' if config.safe else '' }}>
+				</div>
+				<div class="config-div config-div-alts">
+				    <label class="tooltip" for="config-alts">Replace Social Media Links: </label>
+				    <input type="checkbox" name="alts" id="config-alts" {{ 'checked' if config.alts else '' }}>
+				    <div><span class="info-text"> — Replaces Twitter/YouTube/Instagram/Reddit links
+					with Nitter/Invidious/Bibliogram/Libreddit links.</span></div>
+				</div>
+				<div class="config-div config-div-new-tab">
+				    <label for="config-new-tab">Open Links in New Tab: </label>
+				    <input type="checkbox" name="new_tab" id="config-new-tab" {{ 'checked' if config.new_tab else '' }}>
+				</div>
+				<div class="config-div config-div-tor">
+				    <label for="config-tor">Use Tor: {{ '' if tor_available else 'Unavailable' }}</label>
+				    <input type="checkbox" name="tor" id="config-tor" {{ '' if tor_available else 'hidden' }} {{ 'checked' if config.tor else '' }}>
+				</div>
+				<div class="config-div config-div-get-only">
+				    <label for="config-get-only">GET Requests Only: </label>
+				    <input type="checkbox" name="get_only" id="config-get-only" {{ 'checked' if config.get_only else '' }}>
+				</div>
+				<div class="config-div config-div-root-url">
+				    <label for="config-url">Root URL: </label>
+				    <input type="text" name="url" id="config-url" value="{{ config.url }}">
+				</div>
+				<div class="config-div config-div-custom-css">
+				    <label for="config-style">Custom CSS:</label>
+				    <textarea 
+					name="style" 
+					id="config-style"
+					autocapitalize="off"
+					autocomplete="off"
+					spellcheck="false"
+					autocorrect="off"
+					value="">
+					{{ config.style }}
+				    </textarea>
+				</div>
+				<div class="config-div">
+				    <input type="submit" id="config-load" value="Load">&nbsp;
+				    <input type="submit" id="config-submit" value="Apply">&nbsp;
+				    <input type="submit" id="config-save" value="Save As...">
+				</div>
+			    </form>
+			</div>
+		    </div>
+	    {% endif %}
+	    </div>
         <footer>
 			<p style="color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};">
 				Whoogle Search v{{ version_number }} ||

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,3 +1,5 @@
+from app import app
+
 import json
 
 from test.conftest import demo_config
@@ -51,6 +53,17 @@ def test_config(client):
     rv = client.get('/search?q=test' + custom_config)
     assert rv._status_code == 200
     assert custom_config.replace('&', '&amp;') in str(rv.data)
+
+    # Test disabling changing config from client
+    app.config['CONFIG_DISABLE'] = 1
+    dark_mod = not demo_config['dark']
+    demo_config['dark'] = dark_mod
+    rv = client.post('/config', data=demo_config)
+    assert rv._status_code == 403
+
+    rv = client.get('/config')
+    config = json.loads(rv.data)
+    assert config['dark'] != dark_mod
 
 
 def test_opensearch(client):

--- a/whoogle.env
+++ b/whoogle.env
@@ -16,6 +16,7 @@
 #WHOOGLE_CONFIG_COUNTRY=countryUK  # See app/static/settings/countries.json for values
 #WHOOGLE_CONFIG_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
 #WHOOGLE_CONFIG_SEARCH_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
+#WHOOGLE_CONFIG_DISABLE=1   # Disables changing of config from client
 #WHOOGLE_CONFIG_DARK=1  # Dark mode
 #WHOOGLE_CONFIG_SAFE=1  # Safe searches
 #WHOOGLE_CONFIG_ALTS=1  # Use social media site alternatives

--- a/whoogle.env
+++ b/whoogle.env
@@ -15,6 +15,7 @@
 
 #WHOOGLE_CONFIG_COUNTRY=countryUK  # See app/static/settings/countries.json for values
 #WHOOGLE_CONFIG_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
+#WHOOGLE_CONFIG_SEARCH_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
 #WHOOGLE_CONFIG_DARK=1  # Dark mode
 #WHOOGLE_CONFIG_SAFE=1  # Safe searches
 #WHOOGLE_CONFIG_ALTS=1  # Use social media site alternatives


### PR DESCRIPTION
The search language is now set using the WHOOGLE_CONFIG_SEARCH_LANGUAGE
environment variable. Interface language is still set using
WHOOGLE_CONFIG_LANGUAGE.

Fixes #260