### PR TITLE
Add env_file option to docker-compose, refactor whoogle.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,11 @@ Depending on your preferences, you can also deploy the app yourself on your own 
   - A bit more experience or willingness to work through issues
 
 ## Environment Variables
-There are a few optional environment variables available for customizing a Whoogle instance. These can be set manually, or copied into `whoogle.env` and enabled by setting `WHOOGLE_DOTENV=1`.
+There are a few optional environment variables available for customizing a Whoogle instance. These can be set manually, or copied into `whoogle.env` and enabled for your preferred deployment method:
+
+- Local runs: Set `WHOOGLE_DOTENV=1` before running
+- With `docker-compose`: Uncomment the `env_file` option
+- With `docker build/run`: Add `--env-file ./whoogle.env` to your command
 
 | Variable           | Description                                                                               |
 | ------------------ | ----------------------------------------------------------------------------------------- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       #- WHOOGLE_ALT_YT=invidious.snopyta.org
       #- WHOOGLE_ALT_IG=bibliogram.art/u
       #- WHOOGLE_ALT_RD=libredd.it
-      # Load environment variables from whoogle.env
-      #- WHOOGLE_DOTENV=1
+    #env_file: # Alternatively, load variables from whoogle.env
+      #- whoogle.env
     ports:
       - 5000:5000
     restart: unless-stopped

--- a/whoogle.env
+++ b/whoogle.env
@@ -1,5 +1,8 @@
-# You can set Whoogle environment variables here, but must set
-# WHOOGLE_DOTENV=1 in your deployment to enable these values
+# You can set Whoogle environment variables here, but must
+# modify your deployment to enable these values:
+#  - Local: Set WHOOGLE_DOTENV=1
+#  - docker-compose: Uncomment the env_file option
+#  - docker: Add "--env-file ./whoogle.env" to your build command
 
 #WHOOGLE_ALT_TW=nitter.net
 #WHOOGLE_ALT_YT=invidious.snopyta.org
@@ -13,15 +16,27 @@
 #WHOOGLE_PROXY_LOC=""
 #HTTPS_ONLY=1
 
-#WHOOGLE_CONFIG_COUNTRY=countryUK  # See app/static/settings/countries.json for values
-#WHOOGLE_CONFIG_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
-#WHOOGLE_CONFIG_SEARCH_LANGUAGE=lang_en   # See app/static/settings/languages.json for values
-#WHOOGLE_CONFIG_DISABLE=1   # Disables changing of config from client
-#WHOOGLE_CONFIG_DARK=1  # Dark mode
-#WHOOGLE_CONFIG_SAFE=1  # Safe searches
-#WHOOGLE_CONFIG_ALTS=1  # Use social media site alternatives
-#WHOOGLE_CONFIG_TOR=1   # Use Tor if available
-#WHOOGLE_CONFIG_NEW_TAB=1  # Open results in new tab
-#WHOOGLE_CONFIG_GET_ONLY=1 # Search using GET requests only
+# See app/static/settings/countries.json for values
+#WHOOGLE_CONFIG_COUNTRY=countryUK
+# See app/static/settings/languages.json for values
+#WHOOGLE_CONFIG_LANGUAGE=lang_en
+# See app/static/settings/languages.json for values
+#WHOOGLE_CONFIG_SEARCH_LANGUAGE=lang_en
+# Disable changing of config from client
+#WHOOGLE_CONFIG_DISABLE=1
+# Dark mode
+#WHOOGLE_CONFIG_DARK=1
+# Safe search mode
+#WHOOGLE_CONFIG_SAFE=1
+# Use social media site alternatives (nitter, bibliogram, etc)
+#WHOOGLE_CONFIG_ALTS=1
+# Use Tor if available
+#WHOOGLE_CONFIG_TOR=1
+# Open results in new tab
+#WHOOGLE_CONFIG_NEW_TAB=1
+# Search using GET requests only (exposes query in logs)
+#WHOOGLE_CONFIG_GET_ONLY=1
+# Set instance URL
 #WHOOGLE_CONFIG_URL=https://<whoogle url>/
+# Set custom CSS styling/theming
 #WHOOGLE_CONFIG_STYLE=":root { /* LIGHT THEME COLORS */ --whoogle-background: #d8dee9; --whoogle-accent: #2e3440; --whoogle-text: #3B4252; --whoogle-contrast-text: #eceff4; --whoogle-secondary-text: #70757a; --whoogle-result-bg: #fff; --whoogle-result-title: #4c566a; --whoogle-result-url: #81a1c1; --whoogle-result-visited: #a3be8c; /* DARK THEME COLORS */ --whoogle-dark-background: #222; --whoogle-dark-accent: #685e79; --whoogle-dark-text: #fff; --whoogle-dark-contrast-text: #000; --whoogle-dark-secondary-text: #bbb; --whoogle-dark-result-bg: #000; --whoogle-dark-result-title: #1967d2; --whoogle-dark-result-url: #4b11a8; --whoogle-dark-result-visited: #bbbbff; }"


### PR DESCRIPTION
The env_file option is a better way of loading environment variables
from whoogle.env, and has been added to docker-compose.yml.

The whoogle.env file had comments after each example setting, and it was
not clear that these comments needed to be removed when setting new
values. The comments for each variable have been moved above the
appropriate variable to reduce confusion.

See #303 for initial discussion