### PR TITLE
Hotfix: check for site filters before modifying query

### DIFF
--- a/app/static/css/dark-theme.css
+++ b/app/static/css/dark-theme.css
@@ -69,6 +69,18 @@ select {
     background-color: var(--whoogle-dark-page-bg) !important;
 }
 
+.x54gtf {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
+.Q0HXG {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
+.LKSyXe {
+    background-color: var(--whoogle-dark-divider) !important;
+}
+
 #search-bar {
     border-color: var(--whoogle-dark-element-bg) !important;
     color: var(--whoogle-dark-text) !important;

--- a/app/static/css/light-theme.css
+++ b/app/static/css/light-theme.css
@@ -40,6 +40,19 @@ select {
     background-color: var(--whoogle-result-bg) !important;   
 }
 
+.x54gtf {
+    background-color: var(--whoogle-divider) !important;
+}
+
+.Q0HXG {
+    background-color: var(--whoogle-divider) !important;
+}
+
+.LKSyXe {
+    background-color: var(--whoogle-divider) !important;
+}
+
+
 a:visited h3 div {
     color: var(--whoogle-result-visited) !important;
 }

--- a/app/static/css/variables.css
+++ b/app/static/css/variables.css
@@ -11,6 +11,7 @@
     --whoogle-result-title: #1967d2;
     --whoogle-result-url: #0d652d;
     --whoogle-result-visited: #4b11a8;
+    --whoogle-divider: #dfe1e5;
 
     /* DARK THEME COLORS */
     --whoogle-dark-logo: #888888;
@@ -23,4 +24,5 @@
     --whoogle-dark-result-title: #dddddd;
     --whoogle-dark-result-url: #eceff4;
     --whoogle-dark-result-visited: #959595;
+    --whoogle-dark-divider: #111111;
 }

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -22,7 +22,7 @@
                             style="background-color: {{ 'var(--whoogle-dark-result-bg)' if config.dark else 'var(--whoogle-result-bg)' }} !important;
                                    color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};
                             type="text" 
-                            value="{{ query[:query.find('-site:')] }}">
+                            value="{{ query[:query.find('-site:')] if '-site:' in query else query }}">
                         <input style="color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }}" id="search-reset" type="reset" value="x">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
                         <input type="submit" style="display: none;">
@@ -54,7 +54,7 @@
                             name="q"
                             spellcheck="false"
                             type="text"
-                            value="{{ query[:query.find('-site:')] }}"
+                            value="{{ query[:query.find('-site:')] if '-site:' in query else query }}"
                             style="background-color: {{ 'var(--whoogle-dark-result-bg)' if config.dark else 'var(--whoogle-result-bg)' }} !important;
                                    color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};
                                    border-bottom: {{ '2px solid var(--whoogle-dark-element-bg)' if config.dark else '0px' }};">


### PR DESCRIPTION
The previous method of removing all site filters from the search query
removed the last letter of the search. This only applies the substring
filter if any site filters are present in the query.

Fixes #306