### PR TITLE
Hotfix: remove site filter for maps links

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ app.default_key = generate_user_key()
 app.no_cookie_ips = []
 app.config['SECRET_KEY'] = os.urandom(32)
 app.config['SESSION_TYPE'] = 'filesystem'
-app.config['VERSION_NUMBER'] = '0.5.0'
+app.config['VERSION_NUMBER'] = '0.5.1'
 app.config['APP_ROOT'] = os.getenv(
     'APP_ROOT',
     os.path.dirname(os.path.abspath(__file__)))

--- a/app/request.py
+++ b/app/request.py
@@ -10,6 +10,7 @@ from stem import Signal, SocketError
 from stem.control import Controller
 
 SEARCH_URL = 'https://www.google.com/search?gbv=1&q='
+MAPS_URL = 'https://maps.google.com/maps'
 AUTOCOMPLETE_URL = ('https://suggestqueries.google.com/'
                     'complete/search?client=toolbar&')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,7 @@ from flask import jsonify, make_response, request, redirect, render_template, \
 from requests import exceptions
 
 from app import app
+from app.filter import strip_blocked_sites
 from app.models.config import Config
 from app.request import Request, TorError
 from app.utils.bangs import resolve_bang
@@ -247,7 +248,7 @@ def search():
             'header.html',
             config=g.user_config,
             logo=render_template('logo.html', dark=g.user_config.dark),
-            query=urlparse.unquote(query),
+            query=strip_blocked_sites(urlparse.unquote(query)),
             search_type=search_util.search_type,
             mobile=g.user_request.mobile)
                 if 'isch' not in search_util.search_type else '')), resp_code

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -20,9 +20,9 @@
                             class="noHIxc" 
                             name="q"
                             style="background-color: {{ 'var(--whoogle-dark-result-bg)' if config.dark else 'var(--whoogle-result-bg)' }} !important;
-                                   color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};
+                                   color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};"
                             type="text" 
-                            value="{{ query[:query.find('-site:')] if '-site:' in query else query }}">
+                            value="{{ query }}">
                         <input style="color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }}" id="search-reset" type="reset" value="x">
                         <input name="tbm" value="{{ search_type }}" style="display: none">
                         <input type="submit" style="display: none;">
@@ -54,7 +54,7 @@
                             name="q"
                             spellcheck="false"
                             type="text"
-                            value="{{ query[:query.find('-site:')] if '-site:' in query else query }}"
+                            value="{{ query }}"
                             style="background-color: {{ 'var(--whoogle-dark-result-bg)' if config.dark else 'var(--whoogle-result-bg)' }} !important;
                                    color: {{ 'var(--whoogle-dark-text)' if config.dark else 'var(--whoogle-text)' }};
                                    border-bottom: {{ '2px solid var(--whoogle-dark-element-bg)' if config.dark else '0px' }};">

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -1,10 +1,12 @@
-from app.filter import Filter, get_first_link
-from app.request import gen_query
+import os
+from typing import Any
+
 from bs4 import BeautifulSoup as bsoup
 from cryptography.fernet import Fernet, InvalidToken
 from flask import g
-from typing import Any, Tuple
-import os
+
+from app.filter import Filter, get_first_link
+from app.request import gen_query
 
 TOR_BANNER = '<hr><h1 style="text-align: center">You are using Tor</h1><hr>'
 CAPTCHA = 'div class="g-recaptcha"'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     author='Ben Busby',
     author_email='benbusby@protonmail.com',
     name='whoogle-search',
-    version='0.5.0',
+    version='0.5.1',
     include_package_data=True,
     install_requires=requirements,
     description='Self-hosted, ad-free, privacy-respecting metasearch engine',


### PR DESCRIPTION
The new site filter breaks links to Maps results, so filter.py needed
to be updated to handle these links as a unique case. A new method was
introduced to easily remove any "-site:..." filters from the query,
which is now also used to format queries in the header template rather
than manually removing the blocked site list within the template itself.

Bumps version to 0.5.1 for releasing the bugfix

Fixes #329