### PR TITLE
Revert changes to default language config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Contents
     1. [Set Primary Search Engine](#set-whoogle-as-your-primary-search-engine)
     2. [Prevent Downtime (Heroku Only)](#prevent-downtime-heroku-only)
     3. [Manual HTTPS Enforcement](#https-enforcement)
+    4. [Using with Firefox Containers](#using-with-firefox-containers)
 7. [Contributing](#contributing)
 8. [FAQ](#faq)
 9. [Public Instances](#public-instances)
@@ -342,7 +343,12 @@ To filter by a range of time, append ":past <time>" to the end of your search, w
 
 Browser settings:
   - Firefox (Desktop)
-    - Navigate to your app's url, and click the 3 dot menu in the address bar. At the bottom, there should be an option to "Add Search Engine". Once you've clicked this, open your Firefox Preferences menu, click "Search" in the left menu, and use the available dropdown to select "Whoogle" from the list.
+    - Version 89+
+      - Navigate to your app's url, right click the address bar, and select "Add Search Engine".
+    - Previous versions
+      - Navigate to your app's url, and click the 3 dot menu in the address bar. At the bottom, there should be an option to "Add Search Engine".
+    - Once you've added the new search engine, open your Firefox Preferences menu, click "Search" in the left menu, and use the available dropdown to select "Whoogle" from the list.
+    - **Note**: If your Whoogle instance uses Firefox Containers, you'll need to [go through the steps here](#using-with-firefox-containers) to get it working properly.
   - Firefox (iOS)
     - In the mobile app Settings page, tap "Search" within the "General" section. There should be an option titled "Add Search Engine" to select. It should prompt you to enter a title and search query url - use the following elements to fill out the form:
       - Title: "Whoogle"
@@ -395,6 +401,15 @@ Note: You should have your own domain name and [an https certificate](https://le
 - Docker image: Set the environment variable HTTPS_ONLY=1
 - Pip/Pipx: Add the `--https-only` flag to the end of the `whoogle-search` command
 - Default `run` script: Modify the script locally to include the `--https-only` flag at the end of the python run command
+	
+### Using with Firefox Containers
+Unfortunately, Firefox Containers do not currently pass through `POST` requests (the default) to the engine, and Firefox caches the opensearch template on initial page load. To get around this, you can take the following steps to get it working as expected:
+
+1. Remove any existing Whoogle search engines from Firefox settings
+2. Enable `GET Requests Only` in Whoogle config
+3. Clear Firefox cache
+4. Restart Firefox
+5. Navigate to Whoogle instance and [re-add the engine](#set-whoogle-as-your-primary-search-engine)
 
 ## Contributing
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,7 +23,7 @@ app.default_key = generate_user_key()
 app.no_cookie_ips = []
 app.config['SECRET_KEY'] = os.urandom(32)
 app.config['SESSION_TYPE'] = 'filesystem'
-app.config['VERSION_NUMBER'] = '0.5.3'
+app.config['VERSION_NUMBER'] = '0.5.4'
 app.config['APP_ROOT'] = os.getenv(
     'APP_ROOT',
     os.path.dirname(os.path.abspath(__file__)))

--- a/app/request.py
+++ b/app/request.py
@@ -20,9 +20,6 @@ DESKTOP_UA = '{}/5.0 (X11; {} x86_64; rv:75.0) Gecko/20100101 {}/75.0'
 # Valid query params
 VALID_PARAMS = ['tbs', 'tbm', 'start', 'near', 'source', 'nfpr']
 
-# Fallback language if none have been configured
-DEFAULT_LANG = 'lang_en'
-
 
 class TorError(Exception):
     """Exception raised for errors in Tor requests.
@@ -112,7 +109,7 @@ def gen_query(query, args, config, near_city=None) -> str:
         )) if lang else ''
     else:
         param_dict['lr'] = '&lr=' + (
-            config.lang_search if config.lang_search else DEFAULT_LANG
+            config.lang_search if config.lang_search else ''
         )
 
     # 'nfpr' defines the exclusion of results from an auto-corrected query
@@ -122,7 +119,7 @@ def gen_query(query, args, config, near_city=None) -> str:
     param_dict['cr'] = ('&cr=' + config.ctry) if config.ctry else ''
     param_dict['hl'] = '&hl=' + (
         config.lang_interface.replace('lang_', '')
-        if config.lang_interface else DEFAULT_LANG.replace('lang_', '')
+        if config.lang_interface else ''
     )
     param_dict['safe'] = '&safe=' + ('active' if config.safe else 'off')
 
@@ -158,7 +155,7 @@ class Request:
         send_tor_signal(Signal.HEARTBEAT)
 
         self.language = (
-            config.lang_search if config.lang_search else DEFAULT_LANG
+            config.lang_search if config.lang_search else ''
         )
         self.mobile = 'Android' in normal_ua or 'iPhone' in normal_ua
         self.modified_user_agent = gen_user_agent(self.mobile)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     author='Ben Busby',
     author_email='benbusby@protonmail.com',
     name='whoogle-search',
-    version='0.5.3',
+    version='0.5.4',
     include_package_data=True,
     install_requires=requirements,
     description='Self-hosted, ad-free, privacy-respecting metasearch engine',


### PR DESCRIPTION
A recent issue brought up a good point about how the latest changes to
setting default language to english break functionality for bilingual
users. The change was likely not the best solution for users who were
being affected by IP geolocation on their instances -- the right
solution for that would be to configure the interface/search language to
their preference instead.