### PR TITLE
Use cache busting for css/js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ app/static/custom_config
 app/static/bangs
 
 # pip stuff
-build/
+/build/
 dist/
 *.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ COPY app/ app/
 COPY run .
 COPY whoogle.env .
 
+# Allow writing symlinks to build dir
+RUN chown 102:102 app/static/build
+
 EXPOSE $EXPOSE_PORT
 
 HEALTHCHECK  --interval=30s --timeout=5s \

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,7 +101,12 @@ for cb_dir in cache_busting_dirs:
         full_cb_path = os.path.join(full_cb_dir, cb_file)
         cb_file_link = gen_file_hash(full_cb_dir, cb_file)
         build_path = os.path.join(app.config['BUILD_FOLDER'], cb_file_link)
-        os.symlink(full_cb_path, build_path)
+
+        try:
+            os.symlink(full_cb_path, build_path)
+        except FileExistsError:
+            # Symlink hasn't changed, ignore
+            pass
 
         # Create mapping for relative path urls
         map_path = build_path.replace(app.config['APP_ROOT'], '')

--- a/app/filter.py
+++ b/app/filter.py
@@ -173,8 +173,12 @@ class Filter:
                     break
 
             # Create the new details element to wrap around the result's
-            # immediate parent
-            parent = result_children[0].parent
+            # first parent
+            parent = None
+            idx = 0
+            while not parent and idx < len(result_children):
+                parent = result_children[idx].parent
+                idx += 1
             details = BeautifulSoup(features='html.parser').new_tag('details')
             summary = BeautifulSoup(features='html.parser').new_tag('summary')
             summary.string = label

--- a/app/static/build/.gitignore
+++ b/app/static/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/app/static/css/dark-theme.css
+++ b/app/static/css/dark-theme.css
@@ -61,6 +61,10 @@ select {
     background-color: var(--whoogle-dark-result-bg) !important;   
 }
 
+.BVG0Nb {
+    background-color: var(--whoogle-dark-result-bg) !important; 
+}
+
 .bRsWnc {
     background-color: var(--whoogle-dark-result-bg) !important;   
 }

--- a/app/static/css/light-theme.css
+++ b/app/static/css/light-theme.css
@@ -36,6 +36,10 @@ select {
     background-color: var(--whoogle-result-bg) !important;   
 }
 
+.BVG0Nb {
+    background-color: var(--whoogle-result-bg) !important; 
+}
+
 .bRsWnc {
     background-color: var(--whoogle-result-bg) !important;   
 }

--- a/app/static/css/system-theme.css
+++ b/app/static/css/system-theme.css
@@ -1,2 +1,0 @@
-@import "/static/css/light-theme.css" screen;
-@import "/static/css/dark-theme.css" screen and (prefers-color-scheme: dark);

--- a/app/templates/display.html
+++ b/app/templates/display.html
@@ -5,14 +5,21 @@
         <link rel="search" href="opensearch.xml" type="application/opensearchdescription+xml" title="Whoogle Search">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="referrer" content="no-referrer">
-        <link rel="stylesheet" href="static/css/input.css">
-        <link rel="stylesheet" href="static/css/search.css">
-        <link rel="stylesheet" href="static/css/variables.css">
-        <link rel="stylesheet" href="static/css/header.css">
-        {% if config.theme %}
-        <link rel="stylesheet" href="static/css/{{ config.theme }}-theme.css"/>
+        <link rel="stylesheet" href="{{ cb_url('input.css') }}">
+        <link rel="stylesheet" href="{{ cb_url('search.css') }}">
+        <link rel="stylesheet" href="{{ cb_url('variables.css') }}">
+        <link rel="stylesheet" href="{{ cb_url('header.css') }}">
+        {% if config.theme  %}
+            {% if config.theme == 'system' %}
+            <style>
+                @import "{{ cb_url('light-theme.css') }}" screen;
+                @import "{{ cb_url('dark-theme.css') }}" screen and (prefers-color-scheme: dark);
+            </style>
+            {% else %}
+            <link rel="stylesheet" href="{{ cb_url(config.theme + '-theme.css') }}"/>
+            {% endif %}
         {% else %}
-        <link rel="stylesheet" href="static/css/{{ 'dark' if config.dark else 'light' }}-theme.css"/>
+		<link rel="stylesheet" href="{{ cb_url(('dark' if config.dark else 'light') + '-theme.css') }}"/>
         {% endif %}
         <style>{{ config.style }}</style>
         <title>{{ clean_query(query) }} - Whoogle Search</title>
@@ -33,7 +40,7 @@
             <a id="gh-link" href="https://github.com/benbusby/whoogle-search">{{ translation['github-link'] }}</a>
         </p>
     </footer>
-	<script src="static/js/autocomplete.js"></script>
-	<script src="static/js/utils.js"></script>
-	<script src="static/js/keyboard.js"></script>
+    <script src="{{ cb_url('autocomplete.js') }}"></script>
+    <script src="{{ cb_url('utils.js') }}"></script>
+    <script src="{{ cb_url('keyboard.js') }}"></script>
 </html>

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -62,4 +62,4 @@
     </header>
 {% endif %}
 
-<script type="text/javascript" src="static/js/header.js"></script>
+<script type="text/javascript" src="{{ cb_url('header.js') }}"></script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,17 +17,24 @@
 		<meta name="referrer" content="no-referrer">
 		<meta name="msapplication-TileColor" content="#ffffff">
 		<meta name="msapplication-TileImage" content="static/img/favicon/ms-icon-144x144.png">
-		<script type="text/javascript" src="static/js/autocomplete.js"></script>
-		<script type="text/javascript" src="static/js/controller.js"></script>
+        <script type="text/javascript" src="{{ cb_url('autocomplete.js') }}"></script>
+        <script type="text/javascript" src="{{ cb_url('controller.js') }}"></script>
 		<link rel="search" href="opensearch.xml" type="application/opensearchdescription+xml" title="Whoogle Search">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="stylesheet" href="static/css/variables.css">
+        <link rel="stylesheet" href="{{ cb_url('variables.css') }}">
         {% if config.theme  %}
-		<link rel="stylesheet" href="static/css/{{ config.theme }}-theme.css"/>
+            {% if config.theme == 'system' %}
+            <style>
+                @import "{{ cb_url('light-theme.css') }}" screen;
+                @import "{{ cb_url('dark-theme.css') }}" screen and (prefers-color-scheme: dark);
+            </style>
+            {% else %}
+            <link rel="stylesheet" href="{{ cb_url(config.theme + '-theme.css') }}"/>
+            {% endif %}
         {% else %}
-		<link rel="stylesheet" href="static/css/{{ 'dark' if config.dark else 'light' }}-theme.css"/>
+		<link rel="stylesheet" href="{{ cb_url(('dark' if config.dark else 'light') + '-theme.css') }}"/>
         {% endif %}
-		<link rel="stylesheet" href="static/css/main.css">
+        <link rel="stylesheet" href="{{ cb_url('main.css') }}">
 		<noscript>
 			<style>
 				#main { display: inherit !important; }

--- a/app/templates/logo.html
+++ b/app/templates/logo.html
@@ -1,4 +1,4 @@
-    <link rel="stylesheet" href="static/css/logo.css">
+    <link rel="stylesheet" href="{{ cb_url('logo.css') }}">
     <svg id="Layer_1" class="whoogle-svg" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1028 254">
         <defs>
             <style>

--- a/app/utils/misc.py
+++ b/app/utils/misc.py
@@ -1,0 +1,10 @@
+import hashlib
+import os
+
+
+def gen_file_hash(path: str, static_file: str) -> str:
+    file_contents = open(os.path.join(path, static_file), 'rb').read()
+    file_hash = hashlib.md5(file_contents).hexdigest()[:8]
+    filename_split = os.path.splitext(static_file)
+
+    return filename_split[0] + '.' + file_hash + filename_split[-1]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - no-new-privileges
     cap_drop:
       - ALL
-    read_only: true
     tmpfs:
       - /config/:size=10M,uid=102,gid=102,mode=1700
       - /var/lib/tor/:size=10M,uid=102,gid=102,mode=1700

--- a/run
+++ b/run
@@ -12,6 +12,8 @@ SUBDIR="${1:-app}"
 export APP_ROOT="$SCRIPT_DIR/$SUBDIR"
 export STATIC_FOLDER="$APP_ROOT/static"
 
+rm -rf $STATIC_FOLDER/build
+
 # Check for regular vs test run
 if [[ "$SUBDIR" == "test" ]]; then
     # Set up static files for testing

--- a/run
+++ b/run
@@ -12,8 +12,6 @@ SUBDIR="${1:-app}"
 export APP_ROOT="$SCRIPT_DIR/$SUBDIR"
 export STATIC_FOLDER="$APP_ROOT/static"
 
-rm -rf $STATIC_FOLDER/build
-
 # Check for regular vs test run
 if [[ "$SUBDIR" == "test" ]]; then
     # Set up static files for testing


### PR DESCRIPTION
On app init, short hashes are generated from file checksums to use for
cache busting. These hashes are added into the full file name and used
to symlink to the actual file contents. These symlinks are loaded in the
jinja templates for each page, and can tell the browser to load a new
file if the hash changes.

This is only in place for css and js files, but can be extended in the
future for other file types if needed.